### PR TITLE
feat: add uniqueness checks and update hotness algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - OpenAPI 契约：`openapi.yaml`
 - 统一响应：`{ code, message, data }`
 - 完整接口：鉴权/用户、书目、标签、评论、点赞收藏、排行榜、通知
+- 热度算法：评论×1、收藏×2、点赞×3
 - 支持 `PATCH /books/{id}`、`DELETE /books/{id}`
 
 ## 启动

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,11 +9,13 @@ paths:
   /me:
     get: { summary: 当前用户, responses: { '200': { description: OK } } }
     patch: { summary: 更新当前用户, responses: { '200': { description: OK } } }
+  /users/check-nickname:
+    get: { summary: 校验昵称是否被占用, parameters: [ { in: query, name: nickname, required: true, schema: { type: string } } ], responses: { '200': { description: OK } } }
   /books:
     get:
       summary: 列表
       parameters:
-        - { in: query, name: tab, schema: { type: string, enum: [ hot, new ] } }
+        - { in: query, name: tab, schema: { type: string, enum: [ hot, new ] }, description: 热度=评论×1+收藏×2+点赞×3 }
         - { in: query, name: category, schema: { type: string } }
         - { in: query, name: orientation, schema: { type: string } }
         - { in: query, name: search, schema: { type: string } }
@@ -24,6 +26,13 @@ paths:
     post:
       summary: 新增
       requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/BookCreate' } } } }
+      responses: { '200': { description: OK } }
+  /books/check:
+    get:
+      summary: 校验书名作者唯一性
+      parameters:
+        - { in: query, name: title, required: true, schema: { type: string } }
+        - { in: query, name: author, required: true, schema: { type: string } }
       responses: { '200': { description: OK } }
   /books/{id}:
     get: { summary: 详情, parameters: [ { in: path, name: id, required: true, schema: { type: integer } } ], responses: { '200': { description: OK } } }
@@ -66,7 +75,7 @@ paths:
   /tags:
     post: { summary: 创建标签, requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/TagCreate' } } } }, responses: { '200': { description: OK } } }
   /leaderboard:
-    get: { summary: 排行榜, parameters: [ { in: query, name: type, schema: { type: string, enum: [ champion, rookie ] } }, { in: query, name: limit, schema: { type: integer, default: 10 } } ], responses: { '200': { description: OK } } }
+    get: { summary: 排行榜（热度=评论×1+收藏×2+点赞×3）, parameters: [ { in: query, name: type, schema: { type: string, enum: [ champion, rookie ] } }, { in: query, name: limit, schema: { type: integer, default: 10 } } ], responses: { '200': { description: OK } } }
   /notifications:
     get: { summary: 通知列表, parameters: [ { in: query, name: userId, required: true, schema: { type: integer } }, { in: query, name: page, schema: { type: integer, default: 1 } }, { in: query, name: size, schema: { type: integer, default: 20 } } ], responses: { '200': { description: OK } } }
   /notifications/read-all:

--- a/src/main/java/com/novelgrain/application/book/BookUseCases.java
+++ b/src/main/java/com/novelgrain/application/book/BookUseCases.java
@@ -90,4 +90,8 @@ public class BookUseCases {
     public List<Long> listBookmarkedBookIds(Long userId) {
         return bookmarkJpa.findBookIdsByUserId(userId);
     }
+
+    public boolean exists(String title, String author) {
+        return bookRepo.existsByTitleAndAuthor(title, author);
+    }
 }

--- a/src/main/java/com/novelgrain/application/user/UserService.java
+++ b/src/main/java/com/novelgrain/application/user/UserService.java
@@ -49,4 +49,12 @@ public class UserService {
             return userJpa.save(u);
         });
     }
+
+    public boolean nickExists(String nick) {
+        return userJpa.existsByNick(nick);
+    }
+
+    public boolean nickExistsForOther(String nick, Long userId) {
+        return userJpa.findByNick(nick).map(u -> !u.getId().equals(userId)).orElse(false);
+    }
 }

--- a/src/main/java/com/novelgrain/domain/book/BookRepository.java
+++ b/src/main/java/com/novelgrain/domain/book/BookRepository.java
@@ -30,4 +30,6 @@ public interface BookRepository {
     Comment unlikeComment(Long commentId, Long userId);
 
     Comment findComment(Long commentId, Long userId);
+
+    boolean existsByTitleAndAuthor(String title, String author);
 }

--- a/src/main/java/com/novelgrain/infrastructure/adapter/LeaderboardRepositorySqlAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/LeaderboardRepositorySqlAdapter.java
@@ -21,9 +21,9 @@ public class LeaderboardRepositorySqlAdapter implements LeaderboardRepository {
         String timeFilter = "rookie".equalsIgnoreCase(type) ? " AND created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY) " : "";
         String sql = ""
                 + "SELECT u.nick, u.avatar, "
-                + "       (SELECT COUNT(*) FROM book_like l JOIN book b ON b.id=l.book_id WHERE b.recommender_id=u.id " + timeFilter + ") * 1 "
+                + "       (SELECT COUNT(*) FROM comment c JOIN book b ON b.id=c.book_id WHERE b.recommender_id=u.id " + timeFilter + ") * 1 "
                 + "     + (SELECT COUNT(*) FROM book_bookmark bm JOIN book b ON b.id=bm.book_id WHERE b.recommender_id=u.id " + timeFilter + ") * 2 "
-                + "     + (SELECT COUNT(*) FROM comment c JOIN book b ON b.id=c.book_id WHERE b.recommender_id=u.id " + timeFilter + ") * 3 AS score "
+                + "     + (SELECT COUNT(*) FROM book_like l JOIN book b ON b.id=l.book_id WHERE b.recommender_id=u.id " + timeFilter + ") * 3 AS score "
                 + "FROM user u "
                 + "ORDER BY score DESC "
                 + "LIMIT :limit";

--- a/src/main/java/com/novelgrain/infrastructure/jpa/entity/BookPO.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/entity/BookPO.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,7 +24,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "book") // ← 这里改回 book
+@Table(name = "book", uniqueConstraints = @UniqueConstraint(columnNames = {"title", "author"})) // ← 这里改回 book
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/novelgrain/infrastructure/jpa/entity/UserPO.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/entity/UserPO.java
@@ -32,7 +32,7 @@ public class UserPO {
     @Column(name = "wechat_openid", length = 64, unique = true)
     private String wechatOpenid;
 
-    @Column(length = 50)
+    @Column(length = 40, unique = true)
     private String nick;
 
     private String avatar;

--- a/src/main/java/com/novelgrain/infrastructure/jpa/repo/BookJpa.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/repo/BookJpa.java
@@ -16,4 +16,6 @@ public interface BookJpa extends JpaRepository<BookPO, Long>, JpaSpecificationEx
     @EntityGraph(attributePaths = "tags")
     @Query("select b from BookPO b where b.id = :id")
     Optional<BookPO> findByIdWithTags(@Param("id") Long id);
+
+    boolean existsByTitleAndAuthor(String title, String author);
 }

--- a/src/main/java/com/novelgrain/infrastructure/jpa/repo/UserJpa.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/repo/UserJpa.java
@@ -10,4 +10,8 @@ public interface UserJpa extends JpaRepository<UserPO, Long> {
     Optional<UserPO> findByPhone(String phone);
 
     Optional<UserPO> findByWechatOpenid(String openid);
+
+    Optional<UserPO> findByNick(String nick);
+
+    boolean existsByNick(String nick);
 }

--- a/src/main/java/com/novelgrain/interfaces/book/BookController.java
+++ b/src/main/java/com/novelgrain/interfaces/book/BookController.java
@@ -22,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 @RestController
 @RequestMapping("/api/books")
@@ -42,6 +44,12 @@ public class BookController {
         return ApiResponse.ok(use.list(tab, category, orientation, search, tag, page, size));
     }
 
+    @GetMapping("/check")
+    public ApiResponse<Object> check(@RequestParam String title, @RequestParam String author) {
+        boolean exists = use.exists(title, author);
+        return ApiResponse.ok(java.util.Map.of("exists", exists));
+    }
+
     @GetMapping("/{id}")
     public ApiResponse<Book> detail(@PathVariable("id") Long id) {
         return ApiResponse.ok(use.detail(id));
@@ -49,6 +57,9 @@ public class BookController {
 
     @PostMapping
     public ApiResponse<Book> create(@RequestBody CreateReq req) {
+        if (use.exists(req.getTitle(), req.getAuthor())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "书名与作者已存在");
+        }
         var b = use.create(
                 req.getTitle(), req.getAuthor(), req.getOrientation(),
                 req.getCategory(), req.getBlurb(), req.getSummary(),

--- a/src/main/java/com/novelgrain/interfaces/user/MeController.java
+++ b/src/main/java/com/novelgrain/interfaces/user/MeController.java
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 @RestController
 @RequestMapping("/api")
@@ -49,6 +51,9 @@ public class MeController {
         if (uid == null) return ApiResponse.err(401, "未登录");
         String nick = (String) (body.getOrDefault("nickname", body.get("nick")));
         String avatar = (String) body.get("avatar");
+        if (nick != null && userService.nickExistsForOther(nick, uid)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "昵称已被占用");
+        }
         UserPO u = userService.updateProfile(uid, nick, avatar);
         return ApiResponse.ok(Map.of(
                 "id", u.getId(),

--- a/src/main/java/com/novelgrain/interfaces/user/UserController.java
+++ b/src/main/java/com/novelgrain/interfaces/user/UserController.java
@@ -1,0 +1,22 @@
+package com.novelgrain.interfaces.user;
+
+import com.novelgrain.application.user.UserService;
+import com.novelgrain.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping("/check-nickname")
+    public ApiResponse<Object> checkNickname(@RequestParam("nickname") String nickname) {
+        boolean exists = userService.nickExists(nickname);
+        return ApiResponse.ok(java.util.Map.of("exists", exists));
+    }
+}

--- a/src/main/resources/db/migration/V4__unique_title_author_user_nick.sql
+++ b/src/main/resources/db/migration/V4__unique_title_author_user_nick.sql
@@ -1,0 +1,2 @@
+ALTER TABLE book ADD CONSTRAINT uq_book_title_author UNIQUE (title, author);
+ALTER TABLE user ADD CONSTRAINT uq_user_nick UNIQUE (nick);


### PR DESCRIPTION
## Summary
- enforce unique book title-author pairs and user nicknames with checks and new endpoints
- adjust hotness algorithm to weight comments, bookmarks, likes as 1-2-3 and update leaderboard wording
- document and migrate schema for new uniqueness constraints

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable for parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d0c95fc88331a4624f0de5938468