### PR TITLE
feat: add booklist intro and move feature

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -86,7 +86,7 @@ paths:
     get: { summary: 用户书单列表, parameters: [ { in: path, name: userId, required: true, schema: { type: integer } } ], responses: { '200': { description: OK } } }
     post: { summary: 新建书单, parameters: [ { in: path, name: userId, required: true, schema: { type: integer } } ], requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/SheetCreate' } } } }, responses: { '200': { description: OK } } }
   /sheets/{id}:
-    patch: { summary: 重命名书单, parameters: [ { in: path, name: id, required: true, schema: { type: integer } } ], requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/SheetRename' } } } }, responses: { '200': { description: OK } } }
+    patch: { summary: 更新书单, parameters: [ { in: path, name: id, required: true, schema: { type: integer } } ], requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/SheetUpdate' } } } }, responses: { '200': { description: OK } } }
     delete: { summary: 删除书单, parameters: [ { in: path, name: id, required: true, schema: { type: integer } } ], responses: { '200': { description: OK } } }
   /sheets/{id}/books:
     get: { summary: 书单里的书, parameters: [ { in: path, name: id, required: true, schema: { type: integer } } ], responses: { '200': { description: OK } } }
@@ -94,6 +94,8 @@ paths:
   /sheets/{id}/books/{bookId}:
     patch: { summary: 更新书单里书, parameters: [ { in: path, name: id, required: true, schema: { type: integer } }, { in: path, name: bookId, required: true, schema: { type: integer } } ], requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/SheetBookUpdate' } } } }, responses: { '200': { description: OK } } }
     delete: { summary: 移除书单里的书, parameters: [ { in: path, name: id, required: true, schema: { type: integer } }, { in: path, name: bookId, required: true, schema: { type: integer } } ], responses: { '200': { description: OK } } }
+  /sheets/{fromListId}/books/{bookId}/move:
+    post: { summary: 书单间移动书籍, parameters: [ { in: path, name: fromListId, required: true, schema: { type: integer } }, { in: path, name: bookId, required: true, schema: { type: integer } } ], requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/SheetMove' } } } }, responses: { '200': { description: OK } } }
 components:
   schemas:
     BookCreate:
@@ -107,7 +109,6 @@ components:
         blurb: { type: string }
         summary: { type: string }
         tags: { type: array, items: { type: string } }
-        coverUrl: { type: string }
         recommenderId: { type: integer }
     BookUpdate:
       type: object
@@ -118,7 +119,6 @@ components:
         category: { type: string }
         blurb: { type: string }
         summary: { type: string }
-        coverUrl: { type: string }
         tags: { type: array, items: { type: string } }
     CommentCreate:
       type: object
@@ -152,11 +152,12 @@ components:
       required: [ name ]
       properties:
         name: { type: string }
-    SheetRename:
+        intro: { type: string }
+    SheetUpdate:
       type: object
-      required: [ name ]
       properties:
         name: { type: string }
+        intro: { type: string }
     SheetBookCreate:
       type: object
       required: [ title ]
@@ -178,3 +179,8 @@ components:
         category: { type: string }
         rating: { type: integer, nullable: true }
         review: { type: string, nullable: true }
+    SheetMove:
+      type: object
+      required: [ toListId ]
+      properties:
+        toListId: { type: integer }

--- a/src/main/java/com/novelgrain/application/book/BookUseCases.java
+++ b/src/main/java/com/novelgrain/application/book/BookUseCases.java
@@ -32,8 +32,8 @@ public class BookUseCases {
         return bookRepo.findById(id);
     }
 
-    public Book create(String title, String author, String orientation, String category, String blurb, String summary, java.util.List<String> tags, String coverUrl, Long recommenderId) {
-        Book b = Book.builder().title(title).author(author).orientation(orientation).category(category).blurb(blurb).summary(summary).coverUrl(coverUrl).tags(tags).build();
+    public Book create(String title, String author, String orientation, String category, String blurb, String summary, java.util.List<String> tags, Long recommenderId) {
+        Book b = Book.builder().title(title).author(author).orientation(orientation).category(category).blurb(blurb).summary(summary).tags(tags).build();
         return bookRepo.save(b, recommenderId);
     }
 

--- a/src/main/java/com/novelgrain/application/booklist/BookListUseCases.java
+++ b/src/main/java/com/novelgrain/application/booklist/BookListUseCases.java
@@ -16,12 +16,12 @@ public class BookListUseCases {
         return repo.listByUser(userId);
     }
 
-    public BookList create(Long userId, String name) {
-        return repo.create(userId, name);
+    public BookList create(Long userId, String name, String intro) {
+        return repo.create(userId, name, intro);
     }
 
-    public BookList rename(Long id, String name) {
-        return repo.rename(id, name);
+    public BookList update(Long id, String name, String intro) {
+        return repo.update(id, name, intro);
     }
 
     public void delete(Long id) {
@@ -42,5 +42,9 @@ public class BookListUseCases {
 
     public void deleteBook(Long listId, Long bookId) {
         repo.deleteBook(listId, bookId);
+    }
+
+    public void moveBook(Long fromListId, Long bookId, Long toListId) {
+        repo.moveBook(fromListId, bookId, toListId);
     }
 }

--- a/src/main/java/com/novelgrain/domain/booklist/BookList.java
+++ b/src/main/java/com/novelgrain/domain/booklist/BookList.java
@@ -10,6 +10,7 @@ public class BookList {
     private Long id;
     private Long userId;
     private String name;
+    private String intro;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/src/main/java/com/novelgrain/domain/booklist/BookListRepository.java
+++ b/src/main/java/com/novelgrain/domain/booklist/BookListRepository.java
@@ -5,9 +5,9 @@ import java.util.List;
 public interface BookListRepository {
     List<BookList> listByUser(Long userId);
 
-    BookList create(Long userId, String name);
+    BookList create(Long userId, String name, String intro);
 
-    BookList rename(Long id, String name);
+    BookList update(Long id, String name, String intro);
 
     void delete(Long id);
 
@@ -18,4 +18,6 @@ public interface BookListRepository {
     BookListBook updateBook(Long listId, Long bookId, BookListBook patch);
 
     void deleteBook(Long listId, Long bookId);
+
+    void moveBook(Long fromListId, Long bookId, Long toListId);
 }

--- a/src/main/java/com/novelgrain/infrastructure/adapter/BookRepositoryJpaAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/BookRepositoryJpaAdapter.java
@@ -102,7 +102,7 @@ public class BookRepositoryJpaAdapter implements BookRepository {
         var user = userJpa.findById(recommenderId).orElseThrow();
         BookPO po = BookPO.builder()
                 .title(b.getTitle()).author(b.getAuthor()).orientation(b.getOrientation()).category(b.getCategory())
-                .blurb(b.getBlurb()).summary(b.getSummary()).coverUrl(b.getCoverUrl())
+                .blurb(b.getBlurb()).summary(b.getSummary())
                 .recommender(user).likesCount(0).bookmarksCount(0).commentsCount(0)
                 .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
 
@@ -127,7 +127,6 @@ public class BookRepositoryJpaAdapter implements BookRepository {
         if (patch.getCategory() != null) po.setCategory(patch.getCategory());
         if (patch.getBlurb() != null) po.setBlurb(patch.getBlurb());
         if (patch.getSummary() != null) po.setSummary(patch.getSummary());
-        if (patch.getCoverUrl() != null) po.setCoverUrl(patch.getCoverUrl());
         if (patch.getTags() != null) {
             var set = patch.getTags().stream()
                     .map(t -> tagJpa.findByName(t)

--- a/src/main/java/com/novelgrain/infrastructure/jpa/entity/BookListPO.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/entity/BookListPO.java
@@ -24,6 +24,10 @@ public class BookListPO {
     @Column(nullable = false, length = 100)
     private String name;
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String intro;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/novelgrain/infrastructure/jpa/repo/BookListBookJpa.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/repo/BookListBookJpa.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookListBookJpa extends JpaRepository<BookListBookPO, Long> {
     List<BookListBookPO> findByBookList_Id(Long bookListId);
+
+    boolean existsByBookList_IdAndBookId(Long bookListId, Long bookId);
 }

--- a/src/main/java/com/novelgrain/interfaces/book/BookController.java
+++ b/src/main/java/com/novelgrain/interfaces/book/BookController.java
@@ -63,7 +63,7 @@ public class BookController {
         var b = use.create(
                 req.getTitle(), req.getAuthor(), req.getOrientation(),
                 req.getCategory(), req.getBlurb(), req.getSummary(),
-                req.getTags(), req.getCoverUrl(), req.getRecommenderId()
+                req.getTags(), req.getRecommenderId()
         );
         return ApiResponse.ok(b);
     }
@@ -72,7 +72,7 @@ public class BookController {
     public ApiResponse<Book> update(@PathVariable("id") Long id, @RequestBody UpdateReq req) {
         var patch = Book.builder()
                 .title(req.getTitle()).author(req.getAuthor()).orientation(req.getOrientation()).category(req.getCategory())
-                .blurb(req.getBlurb()).summary(req.getSummary()).coverUrl(req.getCoverUrl()).tags(req.getTags()).build();
+                .blurb(req.getBlurb()).summary(req.getSummary()).tags(req.getTags()).build();
         return ApiResponse.ok(use.update(id, patch));
     }
 
@@ -162,8 +162,6 @@ public class BookController {
 
         private java.util.List<String> tags;
 
-        private String coverUrl;
-
         private Long recommenderId;
     }
 
@@ -182,8 +180,6 @@ public class BookController {
         private String summary;
 
         private java.util.List<String> tags;
-
-        private String coverUrl;
     }
 
     @Data

--- a/src/main/java/com/novelgrain/interfaces/booklist/BookListController.java
+++ b/src/main/java/com/novelgrain/interfaces/booklist/BookListController.java
@@ -27,12 +27,12 @@ public class BookListController {
 
     @PostMapping("/api/users/{userId}/sheets")
     public ApiResponse<BookList> create(@PathVariable Long userId, @RequestBody SheetCreateReq req) {
-        return ApiResponse.ok(use.create(userId, req.getName()));
+        return ApiResponse.ok(use.create(userId, req.getName(), req.getIntro()));
     }
 
     @PatchMapping("/api/sheets/{id}")
-    public ApiResponse<BookList> rename(@PathVariable Long id, @RequestBody SheetCreateReq req) {
-        return ApiResponse.ok(use.rename(id, req.getName()));
+    public ApiResponse<BookList> update(@PathVariable Long id, @RequestBody SheetUpdateReq req) {
+        return ApiResponse.ok(use.update(id, req.getName(), req.getIntro()));
     }
 
     @DeleteMapping("/api/sheets/{id}")
@@ -80,9 +80,26 @@ public class BookListController {
         return ApiResponse.ok(null);
     }
 
+    @PostMapping("/api/sheets/{fromListId}/books/{bookId}/move")
+    public ApiResponse<Object> moveBook(@PathVariable("fromListId") Long fromId, @PathVariable("bookId") Long bookId, @RequestBody MoveReq req) {
+        use.moveBook(fromId, bookId, req.getToListId());
+        return ApiResponse.ok(java.util.Map.of(
+                "moved", true,
+                "fromListId", fromId,
+                "toListId", req.getToListId(),
+                "bookId", bookId));
+    }
+
     @Data
     public static class SheetCreateReq {
         private String name;
+        private String intro;
+    }
+
+    @Data
+    public static class SheetUpdateReq {
+        private String name;
+        private String intro;
     }
 
     @Data
@@ -105,5 +122,10 @@ public class BookListController {
         private String category;
         private Integer rating;
         private String review;
+    }
+
+    @Data
+    public static class MoveReq {
+        private Long toListId;
     }
 }


### PR DESCRIPTION
## Summary
- allow setting book list intros and include in API
- add endpoint to move books between lists
- drop cover URL from book create/update flows and spec

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f24c48148331babb6f2c13fc1d8d