### PR TITLE
Add intro column migration for book lists

### DIFF
--- a/src/main/resources/db/migration/V6__add_intro_to_book_lists.sql
+++ b/src/main/resources/db/migration/V6__add_intro_to_book_lists.sql
@@ -1,0 +1,1 @@
+ALTER TABLE book_lists ADD COLUMN IF NOT EXISTS intro TEXT;


### PR DESCRIPTION
## Summary
- add Flyway migration to include `intro` column in `book_lists` table

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f4922dec8331861aae8187363424