### PR TITLE
fix: repair Flyway migrations and add compatibility

### DIFF
--- a/src/main/java/com/novelgrain/config/FlywayConfig.java
+++ b/src/main/java/com/novelgrain/config/FlywayConfig.java
@@ -1,0 +1,25 @@
+package com.novelgrain.config;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Ensures that the Flyway schema history is repaired before running migrations.
+ * This automatically clears out entries for failed migrations which can prevent
+ * the application from starting.
+ */
+@Configuration
+public class FlywayConfig {
+
+    @Bean
+    public FlywayMigrationStrategy repairMigrationStrategy() {
+        return flyway -> {
+            // Repair any failed migrations left from previous runs
+            flyway.repair();
+            // Then continue with the normal migration process
+            flyway.migrate();
+        };
+    }
+}

--- a/src/main/resources/db/migration/V6__add_intro_to_book_lists.sql
+++ b/src/main/resources/db/migration/V6__add_intro_to_book_lists.sql
@@ -1,1 +1,7 @@
-ALTER TABLE book_lists ADD COLUMN IF NOT EXISTS intro TEXT;
+-- Older MySQL versions (prior to 8.0.29) do not support the
+-- `IF NOT EXISTS` clause when adding columns. The earlier version
+-- of this migration used it and caused a failure, leaving a record in
+-- the Flyway schema history table. To keep the migration compatible
+-- and allow it to run after a repair, simply add the column without
+-- the conditional clause.
+ALTER TABLE book_lists ADD COLUMN intro TEXT;


### PR DESCRIPTION
## Summary
- automatically repair Flyway schema history before migrating
- adjust migration adding intro column for older MySQL versions

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f5b546688331998de7aee7d77514