### PR TITLE
fix: propagate HTTP status for API errors

### DIFF
--- a/src/main/java/com/novelgrain/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/novelgrain/common/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.novelgrain.common;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -15,6 +17,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ApiResponse<Void> handleIAE(IllegalArgumentException e) {
         return ApiResponse.err(40001, e.getMessage());
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRse(ResponseStatusException e) {
+        var msg = e.getReason();
+        if (msg == null || msg.isBlank()) {
+            msg = e.getStatusCode().toString();
+        }
+        return ResponseEntity.status(e.getStatusCode())
+                .body(ApiResponse.err(e.getStatusCode().value(), msg));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Summary
- return proper HTTP status codes when a `ResponseStatusException` occurs

## Testing
- `mvn -q -e -U test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f8ae8aa08331bcab7679aca366d6