### PR TITLE
feat: create notifications on interactions

### DIFF
--- a/src/main/java/com/novelgrain/application/notification/NotificationService.java
+++ b/src/main/java/com/novelgrain/application/notification/NotificationService.java
@@ -1,0 +1,64 @@
+package com.novelgrain.application.notification;
+
+import com.novelgrain.domain.notification.NotificationRepository;
+import com.novelgrain.infrastructure.jpa.entity.BookPO;
+import com.novelgrain.infrastructure.jpa.entity.CommentPO;
+import com.novelgrain.infrastructure.jpa.repo.BookJpa;
+import com.novelgrain.infrastructure.jpa.repo.CommentJpa;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository repo;
+    private final BookJpa bookJpa;
+    private final CommentJpa commentJpa;
+
+    public void onBookLiked(Long bookId, Long actorId) {
+        BookPO book = bookJpa.findById(bookId).orElseThrow();
+        Long receiverId = book.getRecommender().getId();
+        if (receiverId.equals(actorId)) return;
+        if (repo.exists("BOOK_LIKED", receiverId, actorId, bookId, null)) return;
+        repo.save("BOOK_LIKED", receiverId, actorId, bookId, null, book.getTitle(), null);
+    }
+
+    public void onBookBookmarked(Long bookId, Long actorId) {
+        BookPO book = bookJpa.findById(bookId).orElseThrow();
+        Long receiverId = book.getRecommender().getId();
+        if (receiverId.equals(actorId)) return;
+        if (repo.exists("BOOK_BOOKMARKED", receiverId, actorId, bookId, null)) return;
+        repo.save("BOOK_BOOKMARKED", receiverId, actorId, bookId, null, book.getTitle(), null);
+    }
+
+    public void onBookCommented(Long bookId, Long actorId, Long commentId, String text) {
+        BookPO book = bookJpa.findById(bookId).orElseThrow();
+        Long receiverId = book.getRecommender().getId();
+        if (receiverId.equals(actorId)) return;
+        repo.save("BOOK_COMMENTED", receiverId, actorId, bookId, commentId, book.getTitle(), excerpt(text));
+    }
+
+    public void onCommentReplied(Long parentCommentId, Long actorId, Long commentId, String text) {
+        if (parentCommentId == null) return;
+        CommentPO parent = commentJpa.findById(parentCommentId).orElse(null);
+        if (parent == null) return;
+        Long receiverId = parent.getUser().getId();
+        if (receiverId.equals(actorId)) return;
+        BookPO book = parent.getBook();
+        repo.save("COMMENT_REPLIED", receiverId, actorId, book.getId(), commentId, book.getTitle(), excerpt(text));
+    }
+
+    public void onCommentLiked(Long commentId, Long actorId) {
+        CommentPO comment = commentJpa.findById(commentId).orElseThrow();
+        Long receiverId = comment.getUser().getId();
+        if (receiverId.equals(actorId)) return;
+        BookPO book = comment.getBook();
+        if (repo.exists("COMMENT_LIKED", receiverId, actorId, book.getId(), commentId)) return;
+        repo.save("COMMENT_LIKED", receiverId, actorId, book.getId(), commentId, book.getTitle(), null);
+    }
+
+    private String excerpt(String text) {
+        if (text == null) return null;
+        return text.length() > 40 ? text.substring(0, 40) : text;
+    }
+}

--- a/src/main/java/com/novelgrain/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/novelgrain/domain/notification/NotificationRepository.java
@@ -10,4 +10,8 @@ public interface NotificationRepository {
     void markRead(Long userId, Long id);
 
     long unreadCount(Long userId);
+
+    boolean exists(String type, Long receiverId, Long actorId, Long bookId, Long commentId);
+
+    void save(String type, Long receiverId, Long actorId, Long bookId, Long commentId, String title, String content);
 }

--- a/src/main/java/com/novelgrain/infrastructure/jpa/repo/NotificationJpa.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/repo/NotificationJpa.java
@@ -12,4 +12,8 @@ public interface NotificationJpa extends JpaRepository<NotificationPO, Long> {
     Page<NotificationPO> findByUserIdAndTypeOrderByCreatedAtDesc(Long userId, String type, Pageable pageable);
 
     long countByUserIdAndReadFalse(Long userId);
+
+    boolean existsByTypeAndUser_IdAndActor_IdAndBook_IdAndCommentIsNull(String type, Long userId, Long actorId, Long bookId);
+
+    boolean existsByTypeAndUser_IdAndActor_IdAndBook_IdAndComment_Id(String type, Long userId, Long actorId, Long bookId, Long commentId);
 }


### PR DESCRIPTION
## Summary
- add notification service to persist events for likes, bookmarks, comments and replies
- wire notification triggers into book use cases
- extend notification repository with save and existence checks

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a110b76b388331865606f41649d9b6