### PR TITLE
Prevent lazy initialization error when paging notifications

### DIFF
--- a/src/main/java/com/novelgrain/infrastructure/adapter/NotificationRepositoryJpaAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/NotificationRepositoryJpaAdapter.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.util.StringUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -27,6 +28,7 @@ public class NotificationRepositoryJpaAdapter implements NotificationRepository 
     private final CommentJpa commentJpa;
 
     @Override
+    @Transactional(readOnly = true)
     public Page<NotificationItem> page(Long userId, String type, int page, int size) {
         var pageable = PageRequest.of(page - 1, size);
         Page<NotificationPO> p;


### PR DESCRIPTION
## Summary
- keep notification paging within a transaction to allow Hibernate to initialize lazy associations

## Testing
- `mvn test -q` (fails: Non-resolvable parent POM due to network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68a11385b71c83318a027285bfa411fb