### PR TITLE
Fix login error when user fields are null

### DIFF
--- a/src/main/java/com/novelgrain/interfaces/auth/AuthController.java
+++ b/src/main/java/com/novelgrain/interfaces/auth/AuthController.java
@@ -49,16 +49,16 @@ public class AuthController {
             return ApiResponse.error(401, "用户名或密码错误");
         }
         String token = JwtUtil.createToken(user.getId(), user.getNick(), 7L*24*3600*1000);
+        Map<String, Object> userMap = new java.util.HashMap<>();
+        userMap.put("id", user.getId());
+        userMap.put("nick", user.getNick());
+        userMap.put("avatar", user.getAvatar());
+        userMap.put("username", user.getUsername());
+        userMap.put("email", user.getEmail());
+        userMap.put("phone", user.getPhone());
         return ApiResponse.ok(Map.of(
                 "token", token,
-                "user", Map.of(
-                        "id", user.getId(),
-                        "nick", user.getNick(),
-                        "avatar", user.getAvatar(),
-                        "username", user.getUsername(),
-                        "email", user.getEmail(),
-                        "phone", user.getPhone()
-                )
+                "user", userMap
         ));
     }
 

--- a/src/main/java/com/novelgrain/interfaces/user/MeController.java
+++ b/src/main/java/com/novelgrain/interfaces/user/MeController.java
@@ -37,14 +37,14 @@ public class MeController {
         if (uid == null) return ApiResponse.err(401, "未登录");
         UserPO u = userService.getById(uid).orElse(null);
         if (u == null) return ApiResponse.err(404, "用户不存在");
-        return ApiResponse.ok(Map.of(
-                "id", u.getId(),
-                "nick", u.getNick(),
-                "avatar", u.getAvatar(),
-                "username", u.getUsername(),
-                "email", u.getEmail(),
-                "phone", u.getPhone()
-        ));
+        Map<String, Object> userMap = new java.util.HashMap<>();
+        userMap.put("id", u.getId());
+        userMap.put("nick", u.getNick());
+        userMap.put("avatar", u.getAvatar());
+        userMap.put("username", u.getUsername());
+        userMap.put("email", u.getEmail());
+        userMap.put("phone", u.getPhone());
+        return ApiResponse.ok(userMap);
     }
 
     @PatchMapping("/me")
@@ -57,14 +57,14 @@ public class MeController {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "昵称已被占用");
         }
         UserPO u = userService.updateProfile(uid, nick, avatar);
-        return ApiResponse.ok(Map.of(
-                "id", u.getId(),
-                "nick", u.getNick(),
-                "avatar", u.getAvatar(),
-                "username", u.getUsername(),
-                "email", u.getEmail(),
-                "phone", u.getPhone()
-        ));
+        Map<String, Object> userMap = new java.util.HashMap<>();
+        userMap.put("id", u.getId());
+        userMap.put("nick", u.getNick());
+        userMap.put("avatar", u.getAvatar());
+        userMap.put("username", u.getUsername());
+        userMap.put("email", u.getEmail());
+        userMap.put("phone", u.getPhone());
+        return ApiResponse.ok(userMap);
     }
 
     private Long currentUserId(HttpServletRequest req) {

--- a/src/main/java/com/novelgrain/security/JwtUtil.java
+++ b/src/main/java/com/novelgrain/security/JwtUtil.java
@@ -14,13 +14,15 @@ public class JwtUtil {
 
     public static String createToken(Long userId, String nick, long ttlMillis) {
         long now = System.currentTimeMillis();
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .setSubject(String.valueOf(userId))
-                .addClaims(Map.of("nick", nick))
                 .setIssuedAt(new Date(now))
                 .setExpiration(new Date(now + ttlMillis))
-                .signWith(KEY, SignatureAlgorithm.HS256)
-                .compact();
+                .signWith(KEY, SignatureAlgorithm.HS256);
+        if (nick != null) {
+            builder.claim("nick", nick);
+        }
+        return builder.compact();
     }
 
     public static Jws<Claims> parse(String token) throws JwtException {


### PR DESCRIPTION
## Summary
- Avoid Map.of usage with nullable fields in AuthController and user endpoints
- Build JWT without Map.of to tolerate missing nick claim

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a123bcdbe88331b05b519f8a23af34