### PR TITLE
fix: persist nick on user registration

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,20 @@ info: { title: NovelGrain Backend API, version: 0.4.0 }
 servers: [ { url: /api } ]
 paths:
   /auth/register:
-    post: { summary: 注册, responses: { '200': { description: OK } } }
+    post:
+      summary: 注册
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ handle, nick, password ]
+              properties:
+                handle: { type: string }
+                nick: { type: string }
+                password: { type: string }
+      responses: { '200': { description: OK } }
   /auth/login:
     post: { summary: 登录, responses: { '200': { description: OK } } }
   /me:

--- a/src/main/java/com/novelgrain/application/user/UserService.java
+++ b/src/main/java/com/novelgrain/application/user/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
     }
 
     @Transactional
-    public UserPO createUser(String handle, String passwordHash) {
+    public UserPO createUser(String handle, String nick, String passwordHash) {
         UserPO u = new UserPO();
         if (handle.contains("@")) {
             u.setEmail(handle);
@@ -45,7 +45,7 @@ public class UserService {
             u.setUsername(handle);
         }
         u.setPasswordHash(passwordHash);
-        u.setNick(handle);
+        u.setNick(nick);
         u.setAvatar("https://i.pravatar.cc/80?u=" + handle);
         return userJpa.save(u);
     }

--- a/src/main/java/com/novelgrain/interfaces/auth/AuthController.java
+++ b/src/main/java/com/novelgrain/interfaces/auth/AuthController.java
@@ -29,12 +29,15 @@ public class AuthController {
     @PostMapping(value="/register", consumes=MediaType.APPLICATION_JSON_VALUE, produces=MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<?> register(@RequestBody @Valid CredentialReq req) {
         String handle = req.getHandle();
+        String nick = req.getNick();
         String password = req.getPassword();
         if (!validHandle(handle)) return ApiResponse.error(400, "用户名 / 邮箱 / 手机号 格式不正确");
         if (password == null || password.length() < 6) return ApiResponse.error(400, "密码至少6位");
+        if (nick == null || nick.isBlank()) return ApiResponse.error(400, "昵称不能为空");
         if (userService.handleExists(handle)) return ApiResponse.error(409, "用户名 / 邮箱 / 手机号 已存在");
+        if (userService.nickExists(nick)) return ApiResponse.error(409, "昵称已存在");
         String hash = encoder.encode(password);
-        userService.createUser(handle, hash);
+        userService.createUser(handle, nick, hash);
         return ApiResponse.ok(Map.of("ok", true));
     }
 
@@ -70,6 +73,7 @@ public class AuthController {
     @Data
     public static class CredentialReq {
         private String handle;
+        private String nick;
         private String password;
     }
 }


### PR DESCRIPTION
## Summary
- honor provided `nick` during registration and ensure uniqueness
- add service method for storing nick
- document registration request body including `nick`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a12a5a57f08331b3ad48f91a561ae9