### PR TITLE
feat: add avatar upload endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,9 +21,36 @@ paths:
     post: { summary: 登录, responses: { '200': { description: OK } } }
   /me:
     get: { summary: 当前用户, responses: { '200': { description: OK } } }
-    patch: { summary: 更新当前用户, responses: { '200': { description: OK } } }
+    patch:
+      summary: 更新当前用户
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nickname: { type: string }
+                nick: { type: string }
+                avatarUrl: { type: string }
+      responses: { '200': { description: OK } }
   /users/check-nickname:
     get: { summary: 校验昵称是否被占用, parameters: [ { in: query, name: nickname, required: true, schema: { type: string } } ], responses: { '200': { description: OK } } }
+  /uploads/avatar:
+    post:
+      summary: 上传头像
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [ file ]
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses: { '200': { description: OK } }
   /books:
     get:
       summary: 列表

--- a/src/main/java/com/novelgrain/application/user/UserService.java
+++ b/src/main/java/com/novelgrain/application/user/UserService.java
@@ -51,10 +51,10 @@ public class UserService {
     }
 
     @Transactional
-    public UserPO updateProfile(Long id, String nick, String avatar) {
+    public UserPO updateProfile(Long id, String nick, String avatarUrl) {
         UserPO u = userJpa.findById(id).orElseThrow();
         if (nick != null && !nick.isBlank()) u.setNick(nick);
-        if (avatar != null && !avatar.isBlank()) u.setAvatar(avatar);
+        if (avatarUrl != null && !avatarUrl.isBlank()) u.setAvatar(avatarUrl);
         return userJpa.save(u);
     }
 

--- a/src/main/java/com/novelgrain/interfaces/upload/UploadController.java
+++ b/src/main/java/com/novelgrain/interfaces/upload/UploadController.java
@@ -1,0 +1,50 @@
+package com.novelgrain.interfaces.upload;
+
+import com.novelgrain.common.ApiResponse;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/uploads")
+public class UploadController {
+
+    private static final long MAX_SIZE = 2 * 1024 * 1024; // 2MB
+
+    @PostMapping(value = "/avatar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<?> uploadAvatar(@RequestParam("file") MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "未选择文件");
+        }
+        if (file.getSize() > MAX_SIZE) {
+            throw new ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE, "文件过大");
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !(MediaType.IMAGE_JPEG_VALUE.equals(contentType)
+                || MediaType.IMAGE_PNG_VALUE.equals(contentType))) {
+            throw new ResponseStatusException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "仅支持 JPG/PNG 图片");
+        }
+        String ext = MediaType.IMAGE_PNG_VALUE.equals(contentType) ? ".png" : ".jpg";
+        String filename = UUID.randomUUID().toString() + ext;
+        Path uploadDir = Paths.get("uploads");
+        try {
+            Files.createDirectories(uploadDir);
+            Path dest = uploadDir.resolve(filename);
+            file.transferTo(dest);
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "保存文件失败");
+        }
+        return ApiResponse.ok(Map.of("url", "/uploads/" + filename));
+    }
+}

--- a/src/main/java/com/novelgrain/interfaces/user/MeController.java
+++ b/src/main/java/com/novelgrain/interfaces/user/MeController.java
@@ -52,11 +52,11 @@ public class MeController {
         Long uid = currentUserId(req);
         if (uid == null) return ApiResponse.err(401, "未登录");
         String nick = (String) (body.getOrDefault("nickname", body.get("nick")));
-        String avatar = (String) body.get("avatar");
+        String avatarUrl = (String) (body.getOrDefault("avatarUrl", body.get("avatar")));
         if (nick != null && userService.nickExistsForOther(nick, uid)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "昵称已被占用");
         }
-        UserPO u = userService.updateProfile(uid, nick, avatar);
+        UserPO u = userService.updateProfile(uid, nick, avatarUrl);
         Map<String, Object> userMap = new java.util.HashMap<>();
         userMap.put("id", u.getId());
         userMap.put("nick", u.getNick());


### PR DESCRIPTION
## Summary
- support PATCH `/api/me` with `avatarUrl`
- add `POST /api/uploads/avatar` for uploading avatar images
- document avatar upload API in OpenAPI spec

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:pom:3.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a130082f0083319c7ee6f3d8d6eb7a