### PR TITLE
fix: persist comment like notifications

### DIFF
--- a/src/main/java/com/novelgrain/application/notification/NotificationService.java
+++ b/src/main/java/com/novelgrain/application/notification/NotificationService.java
@@ -7,9 +7,11 @@ import com.novelgrain.infrastructure.jpa.repo.BookJpa;
 import com.novelgrain.infrastructure.jpa.repo.CommentJpa;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class NotificationService {
     private final NotificationRepository repo;
     private final BookJpa bookJpa;

--- a/src/main/java/com/novelgrain/infrastructure/adapter/NotificationRepositoryJpaAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/NotificationRepositoryJpaAdapter.java
@@ -73,6 +73,7 @@ public class NotificationRepositoryJpaAdapter implements NotificationRepository 
     }
 
     @Override
+    @Transactional
     public void save(String type, Long receiverId, Long actorId, Long bookId, Long commentId, String title, String content) {
         UserPO receiver = userJpa.findById(receiverId).orElseThrow();
         UserPO actor = userJpa.findById(actorId).orElseThrow();


### PR DESCRIPTION
## Summary
- mark notification service transactional
- ensure repository saves run in transaction

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1495bee648331ae383eb2fb6462e1