### PR TITLE
Fix hot books sorting by using formula field

### DIFF
--- a/src/main/java/com/novelgrain/infrastructure/adapter/BookRepositoryJpaAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/BookRepositoryJpaAdapter.java
@@ -82,8 +82,7 @@ public class BookRepositoryJpaAdapter implements BookRepository {
         };
 
         Sort sort = "hot".equalsIgnoreCase(tab)
-                ? JpaSort.unsafe(Sort.Direction.DESC, "(comments_count * 1 + bookmarks_count * 2 + likes_count * 3)")
-                        .and(Sort.by(Sort.Order.desc("createdAt")))
+                ? Sort.by(Sort.Order.desc("hot"), Sort.Order.desc("createdAt"))
                 : Sort.by(Sort.Order.desc("createdAt"));
 
         var p = bookJpa.findAll(spec, PageRequest.of(page - 1, size, sort));

--- a/src/main/java/com/novelgrain/infrastructure/jpa/entity/BookPO.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/entity/BookPO.java
@@ -17,6 +17,7 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.Formula;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -68,6 +69,9 @@ public class BookPO {
 
     @Column(name = "comments_count")
     private Integer comments;
+
+    @Formula("(comments_count * 1 + bookmarks_count * 2 + likes_count * 3)")
+    private Integer hot;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;


### PR DESCRIPTION
## Summary
- add `hot` field in `BookPO` using `@Formula` to compute popularity
- sort by `hot` field when tab=hot

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68a26f74faf483269a8ef5a19eacf172