### PR TITLE
Expose nickname field in leaderboard API

### DIFF
--- a/src/main/java/com/novelgrain/domain/leaders/LeaderboardItem.java
+++ b/src/main/java/com/novelgrain/domain/leaders/LeaderboardItem.java
@@ -12,7 +12,13 @@ import lombok.NoArgsConstructor;
 public class LeaderboardItem {
     private int rank;
 
-    private String name;
+    /**
+     * User nickname. Historically this API returned the field name as
+     * {@code name}.  Frontend navigation now relies on an explicit
+     * {@code nick} field, so we expose it directly to avoid ambiguity when
+     * constructing user URLs.
+     */
+    private String nick;
 
     private String avatar;
 

--- a/src/main/java/com/novelgrain/infrastructure/adapter/LeaderboardRepositorySqlAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/LeaderboardRepositorySqlAdapter.java
@@ -54,7 +54,9 @@ public class LeaderboardRepositorySqlAdapter implements LeaderboardRepository {
         for (Object[] r : rows) {
             list.add(LeaderboardItem.builder()
                     .rank(rank++)
-                    .name((String) r[0])
+                    // expose user's nickname so the frontend can link to
+                    // their profile reliably
+                    .nick((String) r[0])
                     .avatar((String) r[1])
                     .score(((Number) r[2]).longValue())
                     .build());


### PR DESCRIPTION
## Summary
- return explicit `nick` property for leaderboard entries so user pages can be resolved reliably

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.novelgrain:novelgrain-ddd-backend:0.4.0: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a36a10aa0883268137eefe68da7c7e