### PR TITLE
feat: support recommenderId filter for books API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -60,6 +60,8 @@ paths:
         - { in: query, name: orientation, schema: { type: string } }
         - { in: query, name: search, schema: { type: string } }
         - { in: query, name: tag, schema: { type: string } }
+        - { in: query, name: recommenderId, schema: { type: integer }, description: 推荐人用户ID }
+        - { in: query, name: recommender, schema: { type: string }, description: 推荐人昵称, deprecated: true }
         - { in: query, name: page, schema: { type: integer, default: 1 } }
         - { in: query, name: size, schema: { type: integer, default: 20 } }
       responses: { '200': { description: OK } }

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,18 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/novelgrain/application/book/BookUseCases.java
+++ b/src/main/java/com/novelgrain/application/book/BookUseCases.java
@@ -27,8 +27,9 @@ public class BookUseCases {
 
     private final NotificationService notificationService;
 
-    public PageResponse<Book> list(String tab, String category, String orientation, String search, String tag, int page, int size) {
-        Page<Book> p = bookRepo.page(tab, category, orientation, search, tag, page, size);
+    public PageResponse<Book> list(String tab, String category, String orientation, String search, String tag,
+                                   Long recommenderId, String recommender, int page, int size) {
+        Page<Book> p = bookRepo.page(tab, category, orientation, search, tag, recommenderId, recommender, page, size);
         return new PageResponse<>(p.getContent(), page, size, p.getTotalElements());
     }
 

--- a/src/main/java/com/novelgrain/domain/book/BookRepository.java
+++ b/src/main/java/com/novelgrain/domain/book/BookRepository.java
@@ -3,7 +3,8 @@ package com.novelgrain.domain.book;
 import org.springframework.data.domain.Page;
 
 public interface BookRepository {
-    Page<Book> page(String tab, String category, String orientation, String search, String tag, int page, int size);
+    Page<Book> page(String tab, String category, String orientation, String search, String tag,
+                    Long recommenderId, String recommender, int page, int size);
 
     Book findById(Long id);
 

--- a/src/main/java/com/novelgrain/infrastructure/adapter/BookRepositoryJpaAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/BookRepositoryJpaAdapter.java
@@ -56,7 +56,8 @@ public class BookRepositoryJpaAdapter implements BookRepository {
 
     @Transactional(readOnly = true)
     @Override
-    public Page<Book> page(String tab, String category, String orientation, String search, String tag, int page, int size) {
+    public Page<Book> page(String tab, String category, String orientation, String search, String tag,
+                           Long recommenderId, String recommender, int page, int size) {
         Specification<BookPO> spec = (Root<BookPO> root, CriteriaQuery<?> q, CriteriaBuilder cb) -> {
             var ps = new java.util.ArrayList<Predicate>();
             if (category != null && !category.isBlank() && !"全部".equals(category)) {
@@ -77,6 +78,11 @@ public class BookRepositoryJpaAdapter implements BookRepository {
                 var join = root.join("tags");
                 ps.add(cb.equal(join.get("name"), tag));
                 q.distinct(true);
+            }
+            if (recommenderId != null) {
+                ps.add(cb.equal(root.get("recommender").get("id"), recommenderId));
+            } else if (recommender != null && !recommender.isBlank()) {
+                ps.add(cb.equal(root.get("recommender").get("nick"), recommender));
             }
             return cb.and(ps.toArray(new Predicate[0]));
         };

--- a/src/main/java/com/novelgrain/interfaces/book/BookController.java
+++ b/src/main/java/com/novelgrain/interfaces/book/BookController.java
@@ -38,10 +38,15 @@ public class BookController {
             @RequestParam(name = "orientation", required = false) String orientation,
             @RequestParam(name = "search", required = false) String search,
             @RequestParam(name = "tag", required = false) String tag,
+            @RequestParam(name = "recommenderId", required = false) Long recommenderId,
+            @RequestParam(name = "recommender", required = false) String recommender,
             @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "size", defaultValue = "20") int size
     ) {
-        return ApiResponse.ok(use.list(tab, category, orientation, search, tag, page, size));
+        if (recommenderId != null && recommenderId <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_RECOMMENDER_ID");
+        }
+        return ApiResponse.ok(use.list(tab, category, orientation, search, tag, recommenderId, recommender, page, size));
     }
 
     @GetMapping("/check")

--- a/src/test/java/com/novelgrain/interfaces/book/BookControllerTest.java
+++ b/src/test/java/com/novelgrain/interfaces/book/BookControllerTest.java
@@ -1,0 +1,55 @@
+package com.novelgrain.interfaces.book;
+
+import com.novelgrain.domain.book.Book;
+import com.novelgrain.domain.book.BookRepository;
+import com.novelgrain.infrastructure.jpa.entity.UserPO;
+import com.novelgrain.infrastructure.jpa.repo.UserJpa;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+class BookControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    BookRepository bookRepo;
+
+    @Autowired
+    UserJpa userJpa;
+
+    @Test
+    void listByRecommenderIdReturnsOnlyTheirBooks() throws Exception {
+        var u1 = userJpa.save(UserPO.builder().username("u1").nick("n1").passwordHash("p").build());
+        var u2 = userJpa.save(UserPO.builder().username("u2").nick("n2").passwordHash("p").build());
+        bookRepo.save(Book.builder().title("t1").orientation("o").category("c").build(), u1.getId());
+        bookRepo.save(Book.builder().title("t2").orientation("o").category("c").build(), u2.getId());
+
+        mvc.perform(get("/api/books").param("recommenderId", u1.getId().toString())
+                .param("page", "1").param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.list.length()").value(1))
+                .andExpect(jsonPath("$.data.list[0].recommender.id").value(u1.getId()))
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.size").value(10))
+                .andExpect(jsonPath("$.data.total").value(1));
+    }
+
+    @Test
+    void listByNonExistingRecommenderIdReturnsEmptyList() throws Exception {
+        mvc.perform(get("/api/books").param("recommenderId", "9999"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.list.length()").value(0))
+                .andExpect(jsonPath("$.data.total").value(0));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_UPPER=false
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate.dialect: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false


### PR DESCRIPTION
## Summary
- filter books by recommenderId with nickname fallback
- document recommenderId query param in /books endpoint
- add tests for recommenderId filtering and pagination

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a39a4c7a8483269cc35a57136137d7