### PR TITLE
Support new categories and fuzzy search

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,7 +56,7 @@ paths:
       summary: 列表
       parameters:
         - { in: query, name: tab, schema: { type: string, enum: [ hot, new ] }, description: 热度=评论×1+收藏×2+点赞×3 }
-        - { in: query, name: category, schema: { type: string } }
+        - { in: query, name: category, schema: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] } }
         - { in: query, name: orientation, schema: { type: string } }
         - { in: query, name: search, schema: { type: string } }
         - { in: query, name: tag, schema: { type: string } }
@@ -157,7 +157,7 @@ components:
         title: { type: string }
         author: { type: string }
         orientation: { type: string }
-        category: { type: string }
+        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
         blurb: { type: string }
         summary: { type: string }
         tags: { type: array, items: { type: string } }
@@ -168,7 +168,7 @@ components:
         title: { type: string }
         author: { type: string }
         orientation: { type: string }
-        category: { type: string }
+        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
         blurb: { type: string }
         summary: { type: string }
         tags: { type: array, items: { type: string } }
@@ -179,7 +179,7 @@ components:
         title: { type: string }
         author: { type: string }
         orientation: { type: string }
-        category: { type: string }
+        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
         blurb: { type: string }
         summary: { type: string }
         tags: { type: array, items: { type: string } }
@@ -231,7 +231,7 @@ components:
         title: { type: string }
         author: { type: string }
         orientation: { type: string }
-        category: { type: string }
+        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
         rating: { type: integer, nullable: true }
         review: { type: string, nullable: true }
     SheetBookUpdate:
@@ -241,7 +241,7 @@ components:
         title: { type: string }
         author: { type: string }
         orientation: { type: string }
-        category: { type: string }
+        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
         rating: { type: integer, nullable: true }
         review: { type: string, nullable: true }
     SheetMove:

--- a/src/main/java/com/novelgrain/application/book/BookUseCases.java
+++ b/src/main/java/com/novelgrain/application/book/BookUseCases.java
@@ -4,6 +4,7 @@ import com.novelgrain.common.PageResponse;
 import com.novelgrain.domain.book.Book;
 import com.novelgrain.domain.book.BookRepository;
 import com.novelgrain.domain.book.Comment;
+import com.novelgrain.domain.book.BookCategories;
 import com.novelgrain.infrastructure.jpa.repo.BookBookmarkJpa;
 import com.novelgrain.infrastructure.jpa.repo.BookLikeJpa;
 import com.novelgrain.application.notification.NotificationService;
@@ -38,6 +39,7 @@ public class BookUseCases {
     }
 
     public Book create(String title, String author, String orientation, String category, String blurb, String summary, java.util.List<String> tags, Long recommenderId) {
+        validateCategory(category);
         Book b = Book.builder().title(title).author(author).orientation(orientation).category(category).blurb(blurb).summary(summary).tags(tags).build();
         return bookRepo.save(b, recommenderId);
     }
@@ -66,12 +68,22 @@ public class BookUseCases {
         if (patch.getOrientation() != null && patch.getOrientation().length() > 20)
             throw new org.springframework.web.server.ResponseStatusException(
                     org.springframework.http.HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
-        if (patch.getCategory() != null && patch.getCategory().length() > 20)
-            throw new org.springframework.web.server.ResponseStatusException(
-                    org.springframework.http.HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+        if (patch.getCategory() != null) {
+            if (patch.getCategory().length() > 20)
+                throw new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+            validateCategory(patch.getCategory());
+        }
         if (patch.getBlurb() != null && patch.getBlurb().length() > 200)
             throw new org.springframework.web.server.ResponseStatusException(
                     org.springframework.http.HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+    }
+
+    private void validateCategory(String category) {
+        if (category == null || !BookCategories.ALL.contains(category)) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.BAD_REQUEST, "INVALID_CATEGORY");
+        }
     }
 
     public void delete(Long id, Long requesterId) {

--- a/src/main/java/com/novelgrain/domain/book/BookCategories.java
+++ b/src/main/java/com/novelgrain/domain/book/BookCategories.java
@@ -1,0 +1,30 @@
+package com.novelgrain.domain.book;
+
+import java.util.Set;
+
+/**
+ * Allowed book categories used across the application.
+ */
+public final class BookCategories {
+    private BookCategories() {}
+
+    public static final Set<String> ALL = Set.of(
+            "爱情",
+            "剧情",
+            "都市",
+            "历史",
+            "奇幻",
+            "仙侠",
+            "同人",
+            "海棠",
+            "酸涩",
+            "职场",
+            "无限流",
+            "快穿",
+            "游戏",
+            "科幻",
+            "童话",
+            "惊悚",
+            "悬疑"
+    );
+}

--- a/src/main/java/com/novelgrain/infrastructure/adapter/BookRepositoryJpaAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/BookRepositoryJpaAdapter.java
@@ -67,12 +67,14 @@ public class BookRepositoryJpaAdapter implements BookRepository {
                 ps.add(cb.equal(root.get("orientation"), orientation));
             }
             if (search != null && !search.isBlank()) {
-                String like = "%" + search + "%";
-                ps.add(cb.or(
-                        cb.like(root.get("title"), like),
-                        cb.like(root.get("author"), like),
-                        cb.like(root.get("blurb"), like)
-                ));
+                var ors = new java.util.ArrayList<Predicate>();
+                for (String token : search.trim().toLowerCase().split("\\s+")) {
+                    String like = "%" + token + "%";
+                    ors.add(cb.like(cb.lower(root.get("title")), like));
+                    ors.add(cb.like(cb.lower(root.get("author")), like));
+                    ors.add(cb.like(cb.lower(root.get("blurb")), like));
+                }
+                ps.add(cb.or(ors.toArray(new Predicate[0])));
             }
             if (tag != null && !tag.isBlank()) {
                 var join = root.join("tags");

--- a/src/test/java/com/novelgrain/interfaces/book/BookControllerTest.java
+++ b/src/test/java/com/novelgrain/interfaces/book/BookControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -32,8 +32,8 @@ class BookControllerTest {
     void listByRecommenderIdReturnsOnlyTheirBooks() throws Exception {
         var u1 = userJpa.save(UserPO.builder().username("u1").nick("n1").passwordHash("p").build());
         var u2 = userJpa.save(UserPO.builder().username("u2").nick("n2").passwordHash("p").build());
-        bookRepo.save(Book.builder().title("t1").orientation("o").category("c").build(), u1.getId());
-        bookRepo.save(Book.builder().title("t2").orientation("o").category("c").build(), u2.getId());
+        bookRepo.save(Book.builder().title("t1").orientation("o").category("爱情").build(), u1.getId());
+        bookRepo.save(Book.builder().title("t2").orientation("o").category("爱情").build(), u2.getId());
 
         mvc.perform(get("/api/books").param("recommenderId", u1.getId().toString())
                 .param("page", "1").param("size", "10"))
@@ -51,5 +51,33 @@ class BookControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.list.length()").value(0))
                 .andExpect(jsonPath("$.data.total").value(0));
+    }
+
+    @Test
+    void fuzzySearchMatchesPartialKeywords() throws Exception {
+        var u = userJpa.save(UserPO.builder().username("u3").nick("n3").passwordHash("p").build());
+        bookRepo.save(Book.builder().title("Alpha").orientation("o").category("爱情").blurb("desc").build(), u.getId());
+        bookRepo.save(Book.builder().title("Bravo").orientation("o").category("爱情").blurb("desc").build(), u.getId());
+
+        mvc.perform(get("/api/books").param("search", "alp").param("page", "1").param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.list.length()").value(1))
+                .andExpect(jsonPath("$.data.list[0].title").value("Alpha"));
+
+        mvc.perform(get("/api/books").param("search", "ALP").param("page", "1").param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.list.length()").value(1))
+                .andExpect(jsonPath("$.data.list[0].title").value("Alpha"));
+    }
+
+    @Test
+    void createWithInvalidCategoryReturnsBadRequest() throws Exception {
+        var u = userJpa.save(UserPO.builder().username("u4").nick("n4").passwordHash("p").build());
+        mvc.perform(post("/api/books")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title":"t","orientation":"o","category":"invalid","recommenderId":%d}
+                                """.formatted(u.getId())))
+                .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
## Summary
- validate new category list server-side and document in OpenAPI
- add fuzzy, case-insensitive search to books API
- cover category validation and search behavior with tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a6527c1083269f22b7b496b59e1d