### PR TITLE
Add summary and tags to sheet books

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -223,27 +223,31 @@ components:
       properties:
         name: { type: string }
         intro: { type: string }
-    SheetBookCreate:
-      type: object
-      required: [ title ]
-      properties:
-        bookId: { type: integer, nullable: true }
-        title: { type: string }
-        author: { type: string }
-        orientation: { type: string }
-        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
-        rating: { type: integer, nullable: true }
-        review: { type: string, nullable: true }
-    SheetBookUpdate:
-      type: object
-      properties:
-        bookId: { type: integer, nullable: true }
-        title: { type: string }
-        author: { type: string }
-        orientation: { type: string }
-        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
-        rating: { type: integer, nullable: true }
-        review: { type: string, nullable: true }
+      SheetBookCreate:
+        type: object
+        required: [ title ]
+        properties:
+          bookId: { type: integer, nullable: true }
+          title: { type: string }
+          author: { type: string }
+          orientation: { type: string }
+          category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
+          rating: { type: integer, nullable: true }
+          review: { type: string, nullable: true }
+          summary: { type: string, nullable: true }
+          tags: { type: array, items: { type: string } }
+      SheetBookUpdate:
+        type: object
+        properties:
+          bookId: { type: integer, nullable: true }
+          title: { type: string }
+          author: { type: string }
+          orientation: { type: string }
+          category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
+          rating: { type: integer, nullable: true }
+          review: { type: string, nullable: true }
+          summary: { type: string, nullable: true }
+          tags: { type: array, items: { type: string } }
     SheetMove:
       type: object
       required: [ toListId ]

--- a/src/main/java/com/novelgrain/domain/booklist/BookListBook.java
+++ b/src/main/java/com/novelgrain/domain/booklist/BookListBook.java
@@ -1,6 +1,7 @@
 package com.novelgrain.domain.booklist;
 
 import java.time.Instant;
+import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 
@@ -16,6 +17,8 @@ public class BookListBook {
     private String category;
     private Integer rating;
     private String review;
+    private String summary;
+    private List<String> tags;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/src/main/java/com/novelgrain/infrastructure/jpa/entity/BookListBookPO.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/entity/BookListBookPO.java
@@ -2,6 +2,7 @@ package com.novelgrain.infrastructure.jpa.entity;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Set;
 import lombok.*;
 
 @Entity
@@ -39,6 +40,17 @@ public class BookListBookPO {
     @Lob
     @Column(columnDefinition = "TEXT")
     private String review;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "book_list_book_tags",
+            joinColumns = @JoinColumn(name = "book_list_book_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id"))
+    private Set<TagPO> tags;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/src/main/java/com/novelgrain/interfaces/booklist/BookListController.java
+++ b/src/main/java/com/novelgrain/interfaces/booklist/BookListController.java
@@ -56,6 +56,8 @@ public class BookListController {
                 .category(req.getCategory())
                 .rating(req.getRating())
                 .review(req.getReview())
+                .summary(req.getSummary())
+                .tags(req.getTags())
                 .build();
         return ApiResponse.ok(use.addBook(id, book));
     }
@@ -70,6 +72,8 @@ public class BookListController {
                 .category(req.getCategory())
                 .rating(req.getRating())
                 .review(req.getReview())
+                .summary(req.getSummary())
+                .tags(req.getTags())
                 .build();
         return ApiResponse.ok(use.updateBook(id, bookId, patch));
     }
@@ -111,6 +115,8 @@ public class BookListController {
         private String category;
         private Integer rating;
         private String review;
+        private String summary;
+        private java.util.List<String> tags;
     }
 
     @Data
@@ -122,6 +128,8 @@ public class BookListController {
         private String category;
         private Integer rating;
         private String review;
+        private String summary;
+        private java.util.List<String> tags;
     }
 
     @Data

--- a/src/main/resources/db/migration/V8__sheet_book_summary_tags.sql
+++ b/src/main/resources/db/migration/V8__sheet_book_summary_tags.sql
@@ -1,0 +1,9 @@
+ALTER TABLE book_list_books ADD COLUMN summary TEXT;
+
+CREATE TABLE IF NOT EXISTS book_list_book_tags (
+    book_list_book_id BIGINT NOT NULL,
+    tag_id BIGINT NOT NULL,
+    PRIMARY KEY (book_list_book_id, tag_id),
+    CONSTRAINT fk_blbt_book FOREIGN KEY (book_list_book_id) REFERENCES book_list_books(id) ON DELETE CASCADE,
+    CONSTRAINT fk_blbt_tag FOREIGN KEY (tag_id) REFERENCES tag(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- allow sheet books to store summary text and associated tags
- return persisted tags and summary in sheet book endpoints
- document and migrate database for new summary column and tag join table

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM for com.novelgrain:novelgrain-ddd-backend:0.4.0: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.2 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 6, column 13)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cf22231c8326a5e04df49bf1005e