### PR TITLE
feat: support 女频 orientation and 年代 category

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,8 +56,8 @@ paths:
       summary: 列表
       parameters:
         - { in: query, name: tab, schema: { type: string, enum: [ hot, new ] }, description: 热度=评论×1+收藏×2+点赞×3 }
-        - { in: query, name: category, schema: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] } }
-        - { in: query, name: orientation, schema: { type: string } }
+        - { in: query, name: category, schema: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] } }
+        - { in: query, name: orientation, schema: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] } }
         - { in: query, name: search, schema: { type: string } }
         - { in: query, name: tag, schema: { type: string } }
         - { in: query, name: recommenderId, schema: { type: integer }, description: 推荐人用户ID }
@@ -156,8 +156,8 @@ components:
       properties:
         title: { type: string }
         author: { type: string }
-        orientation: { type: string }
-        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
+        orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
         blurb: { type: string }
         summary: { type: string }
         tags: { type: array, items: { type: string } }
@@ -167,8 +167,8 @@ components:
       properties:
         title: { type: string }
         author: { type: string }
-        orientation: { type: string }
-        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
+        orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
         blurb: { type: string }
         summary: { type: string }
         tags: { type: array, items: { type: string } }
@@ -178,8 +178,8 @@ components:
         id: { type: integer }
         title: { type: string }
         author: { type: string }
-        orientation: { type: string }
-        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
+        orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+        category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
         blurb: { type: string }
         summary: { type: string }
         tags: { type: array, items: { type: string } }
@@ -230,8 +230,8 @@ components:
           bookId: { type: integer, nullable: true }
           title: { type: string }
           author: { type: string }
-          orientation: { type: string }
-          category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
+          orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+          category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
           rating: { type: integer, nullable: true }
           review: { type: string, nullable: true }
           summary: { type: string, nullable: true }
@@ -242,8 +242,8 @@ components:
           bookId: { type: integer, nullable: true }
           title: { type: string }
           author: { type: string }
-          orientation: { type: string }
-          category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑'] }
+          orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+          category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
           rating: { type: integer, nullable: true }
           review: { type: string, nullable: true }
           summary: { type: string, nullable: true }

--- a/src/main/java/com/novelgrain/application/book/BookUseCases.java
+++ b/src/main/java/com/novelgrain/application/book/BookUseCases.java
@@ -5,6 +5,7 @@ import com.novelgrain.domain.book.Book;
 import com.novelgrain.domain.book.BookRepository;
 import com.novelgrain.domain.book.Comment;
 import com.novelgrain.domain.book.BookCategories;
+import com.novelgrain.domain.book.BookOrientations;
 import com.novelgrain.infrastructure.jpa.repo.BookBookmarkJpa;
 import com.novelgrain.infrastructure.jpa.repo.BookLikeJpa;
 import com.novelgrain.application.notification.NotificationService;
@@ -39,6 +40,7 @@ public class BookUseCases {
     }
 
     public Book create(String title, String author, String orientation, String category, String blurb, String summary, java.util.List<String> tags, Long recommenderId) {
+        validateOrientation(orientation);
         validateCategory(category);
         Book b = Book.builder().title(title).author(author).orientation(orientation).category(category).blurb(blurb).summary(summary).tags(tags).build();
         return bookRepo.save(b, recommenderId);
@@ -65,9 +67,12 @@ public class BookUseCases {
         if (patch.getAuthor() != null && patch.getAuthor().length() > 80)
             throw new org.springframework.web.server.ResponseStatusException(
                     org.springframework.http.HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
-        if (patch.getOrientation() != null && patch.getOrientation().length() > 20)
-            throw new org.springframework.web.server.ResponseStatusException(
-                    org.springframework.http.HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+        if (patch.getOrientation() != null) {
+            if (patch.getOrientation().length() > 20)
+                throw new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+            validateOrientation(patch.getOrientation());
+        }
         if (patch.getCategory() != null) {
             if (patch.getCategory().length() > 20)
                 throw new org.springframework.web.server.ResponseStatusException(
@@ -83,6 +88,13 @@ public class BookUseCases {
         if (category == null || !BookCategories.ALL.contains(category)) {
             throw new org.springframework.web.server.ResponseStatusException(
                     org.springframework.http.HttpStatus.BAD_REQUEST, "INVALID_CATEGORY");
+        }
+    }
+
+    private void validateOrientation(String orientation) {
+        if (orientation == null || !BookOrientations.ALL.contains(orientation)) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.BAD_REQUEST, "INVALID_ORIENTATION");
         }
     }
 

--- a/src/main/java/com/novelgrain/domain/book/BookCategories.java
+++ b/src/main/java/com/novelgrain/domain/book/BookCategories.java
@@ -25,6 +25,7 @@ public final class BookCategories {
             "科幻",
             "童话",
             "惊悚",
-            "悬疑"
+            "悬疑",
+            "年代"
     );
 }

--- a/src/main/java/com/novelgrain/domain/book/BookOrientations.java
+++ b/src/main/java/com/novelgrain/domain/book/BookOrientations.java
@@ -1,0 +1,19 @@
+package com.novelgrain.domain.book;
+
+import java.util.Set;
+
+/**
+ * Allowed book orientations used across the application.
+ */
+public final class BookOrientations {
+    private BookOrientations() {}
+
+    public static final Set<String> ALL = Set.of(
+            "BG",
+            "BL",
+            "GL",
+            "无CP",
+            "男频",
+            "女频"
+    );
+}

--- a/src/test/java/com/novelgrain/interfaces/book/BookControllerTest.java
+++ b/src/test/java/com/novelgrain/interfaces/book/BookControllerTest.java
@@ -32,8 +32,8 @@ class BookControllerTest {
     void listByRecommenderIdReturnsOnlyTheirBooks() throws Exception {
         var u1 = userJpa.save(UserPO.builder().username("u1").nick("n1").passwordHash("p").build());
         var u2 = userJpa.save(UserPO.builder().username("u2").nick("n2").passwordHash("p").build());
-        bookRepo.save(Book.builder().title("t1").orientation("o").category("爱情").build(), u1.getId());
-        bookRepo.save(Book.builder().title("t2").orientation("o").category("爱情").build(), u2.getId());
+        bookRepo.save(Book.builder().title("t1").orientation("女频").category("爱情").build(), u1.getId());
+        bookRepo.save(Book.builder().title("t2").orientation("女频").category("爱情").build(), u2.getId());
 
         mvc.perform(get("/api/books").param("recommenderId", u1.getId().toString())
                 .param("page", "1").param("size", "10"))
@@ -56,8 +56,8 @@ class BookControllerTest {
     @Test
     void fuzzySearchMatchesPartialKeywords() throws Exception {
         var u = userJpa.save(UserPO.builder().username("u3").nick("n3").passwordHash("p").build());
-        bookRepo.save(Book.builder().title("Alpha").orientation("o").category("爱情").blurb("desc").build(), u.getId());
-        bookRepo.save(Book.builder().title("Bravo").orientation("o").category("爱情").blurb("desc").build(), u.getId());
+        bookRepo.save(Book.builder().title("Alpha").orientation("女频").category("爱情").blurb("desc").build(), u.getId());
+        bookRepo.save(Book.builder().title("Bravo").orientation("女频").category("爱情").blurb("desc").build(), u.getId());
 
         mvc.perform(get("/api/books").param("search", "alp").param("page", "1").param("size", "10"))
                 .andExpect(status().isOk())
@@ -76,8 +76,31 @@ class BookControllerTest {
         mvc.perform(post("/api/books")
                         .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title":"t","orientation":"o","category":"invalid","recommenderId":%d}
+                                {"title":"t","orientation":"女频","category":"invalid","recommenderId":%d}
                                 """.formatted(u.getId())))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createWithInvalidOrientationReturnsBadRequest() throws Exception {
+        var u = userJpa.save(UserPO.builder().username("u5").nick("n5").passwordHash("p").build());
+        mvc.perform(post("/api/books")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title":"t","orientation":"invalid","category":"爱情","recommenderId":%d}
+                                """.formatted(u.getId())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createWithNewCategorySucceeds() throws Exception {
+        var u = userJpa.save(UserPO.builder().username("u6").nick("n6").passwordHash("p").build());
+        mvc.perform(post("/api/books")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title":"t","orientation":"女频","category":"年代","recommenderId":%d}
+                                """.formatted(u.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.category").value("年代"));
     }
 }


### PR DESCRIPTION
## Summary
- extend book categories with 年代
- validate orientations against new constants including 女频
- document new options in OpenAPI and add tests

## Testing
- `mvn -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a66e0667508326bb3cdc957a51d2c9