### PR TITLE
feat: add tag filtering and listing APIs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,7 +59,8 @@ paths:
         - { in: query, name: category, schema: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] } }
         - { in: query, name: orientation, schema: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] } }
         - { in: query, name: search, schema: { type: string } }
-        - { in: query, name: tag, schema: { type: string } }
+        - { in: query, name: includeTags, schema: { type: string }, description: 以逗号分隔的包含标签 }
+        - { in: query, name: excludeTags, schema: { type: string }, description: 以逗号分隔的排除标签 }
         - { in: query, name: recommenderId, schema: { type: integer }, description: 推荐人用户ID }
         - { in: query, name: recommender, schema: { type: string }, description: 推荐人昵称, deprecated: true }
         - { in: query, name: page, schema: { type: integer, default: 1 } }
@@ -123,6 +124,14 @@ paths:
   /tags/suggest:
     get: { summary: 标签建议, parameters: [ { in: query, name: q, required: true, schema: { type: string } } ], responses: { '200': { description: OK } } }
   /tags:
+    get:
+      summary: 标签列表
+      parameters:
+        - { in: query, name: search, schema: { type: string } }
+        - { in: query, name: page, schema: { type: integer, default: 1 } }
+        - { in: query, name: size, schema: { type: integer, default: 20 } }
+        - { in: query, name: sort, schema: { type: string, enum: [ hot, name ], default: hot } }
+      responses: { '200': { description: OK } }
     post: { summary: 创建标签, requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/TagCreate' } } } }, responses: { '200': { description: OK } } }
   /leaderboard:
     get: { summary: 排行榜（热度=评论×1+收藏×2+点赞×3）, parameters: [ { in: query, name: type, schema: { type: string, enum: [ champion, rookie ] } }, { in: query, name: limit, schema: { type: integer, default: 10 } } ], responses: { '200': { description: OK } } }
@@ -212,6 +221,12 @@ components:
       type: object
       required: [ name ]
       properties: { name: { type: string } }
+    Tag:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        hot: { type: integer }
     SheetCreate:
       type: object
       required: [ name ]

--- a/src/main/java/com/novelgrain/application/book/BookUseCases.java
+++ b/src/main/java/com/novelgrain/application/book/BookUseCases.java
@@ -29,9 +29,11 @@ public class BookUseCases {
 
     private final NotificationService notificationService;
 
-    public PageResponse<Book> list(String tab, String category, String orientation, String search, String tag,
+    public PageResponse<Book> list(String tab, String category, String orientation, String search,
+                                   java.util.List<String> includeTags, java.util.List<String> excludeTags,
                                    Long recommenderId, String recommender, int page, int size) {
-        Page<Book> p = bookRepo.page(tab, category, orientation, search, tag, recommenderId, recommender, page, size);
+        Page<Book> p = bookRepo.page(tab, category, orientation, search, includeTags, excludeTags,
+                recommenderId, recommender, page, size);
         return new PageResponse<>(p.getContent(), page, size, p.getTotalElements());
     }
 

--- a/src/main/java/com/novelgrain/application/tag/TagUseCases.java
+++ b/src/main/java/com/novelgrain/application/tag/TagUseCases.java
@@ -1,6 +1,8 @@
 package com.novelgrain.application.tag;
 
 import com.novelgrain.domain.tag.TagRepository;
+import com.novelgrain.domain.tag.Tag;
+import com.novelgrain.common.PageResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +12,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TagUseCases {
     private final TagRepository tagRepo;
+
+    public PageResponse<Tag> list(String search, int page, int size, String sort) {
+        var p = tagRepo.page(search, page, size, sort);
+        return new PageResponse<>(p.getContent(), page, size, p.getTotalElements());
+    }
 
     public java.util.List<String> suggest(String q) {
         return tagRepo.suggest(q);

--- a/src/main/java/com/novelgrain/domain/book/BookRepository.java
+++ b/src/main/java/com/novelgrain/domain/book/BookRepository.java
@@ -3,7 +3,8 @@ package com.novelgrain.domain.book;
 import org.springframework.data.domain.Page;
 
 public interface BookRepository {
-    Page<Book> page(String tab, String category, String orientation, String search, String tag,
+    Page<Book> page(String tab, String category, String orientation, String search,
+                    java.util.List<String> includeTags, java.util.List<String> excludeTags,
                     Long recommenderId, String recommender, int page, int size);
 
     Book findById(Long id);

--- a/src/main/java/com/novelgrain/domain/tag/Tag.java
+++ b/src/main/java/com/novelgrain/domain/tag/Tag.java
@@ -1,0 +1,16 @@
+package com.novelgrain.domain.tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Tag {
+    private Long id;
+    private String name;
+    private Long hot;
+}

--- a/src/main/java/com/novelgrain/domain/tag/TagRepository.java
+++ b/src/main/java/com/novelgrain/domain/tag/TagRepository.java
@@ -1,6 +1,8 @@
 package com.novelgrain.domain.tag;
 
 public interface TagRepository {
+    org.springframework.data.domain.Page<Tag> page(String search, int page, int size, String sort);
+
     java.util.List<String> suggest(String q);
 
     String createIfAbsent(String name);

--- a/src/main/java/com/novelgrain/infrastructure/adapter/TagRepositoryJpaAdapter.java
+++ b/src/main/java/com/novelgrain/infrastructure/adapter/TagRepositoryJpaAdapter.java
@@ -1,19 +1,46 @@
 package com.novelgrain.infrastructure.adapter;
 
 import com.novelgrain.domain.tag.TagRepository;
+import com.novelgrain.domain.tag.Tag;
 import com.novelgrain.infrastructure.jpa.entity.TagPO;
 import com.novelgrain.infrastructure.jpa.repo.TagJpa;
+import com.novelgrain.infrastructure.jpa.repo.BookJpa;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class TagRepositoryJpaAdapter implements TagRepository {
     private final TagJpa tagJpa;
+    private final BookJpa bookJpa;
+
+    @Override
+    public Page<Tag> page(String search, int page, int size, String sort) {
+        var all = tagJpa.findAll();
+        List<Tag> tags = all.stream()
+                .filter(t -> search == null || search.isBlank() || t.getName().toLowerCase().contains(search.toLowerCase()))
+                .map(t -> Tag.builder().id(t.getId()).name(t.getName())
+                        .hot(bookJpa.countByTags_Id(t.getId())).build())
+                .toList();
+        if ("hot".equalsIgnoreCase(sort)) {
+            tags = tags.stream().sorted(Comparator.comparing(Tag::getHot).reversed().thenComparing(Tag::getName)).toList();
+        } else {
+            tags = tags.stream().sorted(Comparator.comparing(Tag::getName)).toList();
+        }
+        int from = Math.max(0, (page - 1) * size);
+        int to = Math.min(tags.size(), from + size);
+        var sub = tags.subList(from, to);
+        return new PageImpl<>(sub, PageRequest.of(page - 1, size), tags.size());
+    }
 
     @Override
     public java.util.List<String> suggest(String q) {
@@ -22,6 +49,8 @@ public class TagRepositoryJpaAdapter implements TagRepository {
 
     @Override
     public String createIfAbsent(String name) {
-        return tagJpa.findByName(name).orElseGet(() -> tagJpa.save(TagPO.builder().name(name).createdAt(LocalDateTime.now()).build())).getName();
+        return tagJpa.findByName(name)
+                .orElseGet(() -> tagJpa.save(TagPO.builder().name(name).createdAt(LocalDateTime.now()).build()))
+                .getName();
     }
 }

--- a/src/main/java/com/novelgrain/infrastructure/jpa/repo/BookJpa.java
+++ b/src/main/java/com/novelgrain/infrastructure/jpa/repo/BookJpa.java
@@ -18,4 +18,6 @@ public interface BookJpa extends JpaRepository<BookPO, Long>, JpaSpecificationEx
     Optional<BookPO> findByIdWithTags(@Param("id") Long id);
 
     boolean existsByTitleAndAuthor(String title, String author);
+
+    long countByTags_Id(Long tagId);
 }

--- a/src/main/java/com/novelgrain/interfaces/book/BookController.java
+++ b/src/main/java/com/novelgrain/interfaces/book/BookController.java
@@ -37,7 +37,8 @@ public class BookController {
             @RequestParam(name = "category", required = false) String category,
             @RequestParam(name = "orientation", required = false) String orientation,
             @RequestParam(name = "search", required = false) String search,
-            @RequestParam(name = "tag", required = false) String tag,
+            @RequestParam(name = "includeTags", required = false) String includeTags,
+            @RequestParam(name = "excludeTags", required = false) String excludeTags,
             @RequestParam(name = "recommenderId", required = false) Long recommenderId,
             @RequestParam(name = "recommender", required = false) String recommender,
             @RequestParam(name = "page", defaultValue = "1") int page,
@@ -46,7 +47,11 @@ public class BookController {
         if (recommenderId != null && recommenderId <= 0) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_RECOMMENDER_ID");
         }
-        return ApiResponse.ok(use.list(tab, category, orientation, search, tag, recommenderId, recommender, page, size));
+        var include = includeTags == null || includeTags.isBlank() ? java.util.List.<String>of()
+                : java.util.Arrays.stream(includeTags.split(",")).filter(s -> !s.isBlank()).map(String::trim).toList();
+        var exclude = excludeTags == null || excludeTags.isBlank() ? java.util.List.<String>of()
+                : java.util.Arrays.stream(excludeTags.split(",")).filter(s -> !s.isBlank()).map(String::trim).toList();
+        return ApiResponse.ok(use.list(tab, category, orientation, search, include, exclude, recommenderId, recommender, page, size));
     }
 
     @GetMapping("/check")

--- a/src/main/java/com/novelgrain/interfaces/tag/TagController.java
+++ b/src/main/java/com/novelgrain/interfaces/tag/TagController.java
@@ -2,6 +2,8 @@ package com.novelgrain.interfaces.tag;
 
 import com.novelgrain.application.tag.TagUseCases;
 import com.novelgrain.common.ApiResponse;
+import com.novelgrain.common.PageResponse;
+import com.novelgrain.domain.tag.Tag;
 
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TagController {
     private final TagUseCases use;
+
+    @GetMapping
+    public ApiResponse<PageResponse<Tag>> list(
+            @RequestParam(name = "search", required = false) String search,
+            @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @RequestParam(name = "sort", defaultValue = "hot") String sort
+    ) {
+        return ApiResponse.ok(use.list(search, page, size, sort));
+    }
 
     @GetMapping("/suggest")
     public ApiResponse<Object> suggest(@RequestParam String q) {


### PR DESCRIPTION
## Summary
- add `/api/tags` endpoint with search, pagination, and sorting
- support include/exclude tag filters when listing books
- document new tag filtering parameters in OpenAPI spec

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a67308197c8326b3ac4f1660772e75