### PR TITLE
fix: allow flexible book orientations

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,7 +57,7 @@ paths:
       parameters:
         - { in: query, name: tab, schema: { type: string, enum: [ hot, new ] }, description: 热度=评论×1+收藏×2+点赞×3 }
         - { in: query, name: category, schema: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] } }
-        - { in: query, name: orientation, schema: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] } }
+        - { in: query, name: orientation, schema: { type: string }, description: "方位，如 BL、BL主受 等" }
         - { in: query, name: search, schema: { type: string } }
         - { in: query, name: includeTags, schema: { type: string }, description: 以逗号分隔的包含标签 }
         - { in: query, name: excludeTags, schema: { type: string }, description: 以逗号分隔的排除标签 }
@@ -165,7 +165,7 @@ components:
       properties:
         title: { type: string }
         author: { type: string }
-        orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+        orientation: { type: string, description: "方位，如 BL、BL主受 等" }
         category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
         blurb: { type: string }
         summary: { type: string }
@@ -176,7 +176,7 @@ components:
       properties:
         title: { type: string }
         author: { type: string }
-        orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+        orientation: { type: string, description: "方位，如 BL、BL主受 等" }
         category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
         blurb: { type: string }
         summary: { type: string }
@@ -187,7 +187,7 @@ components:
         id: { type: integer }
         title: { type: string }
         author: { type: string }
-        orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+        orientation: { type: string, description: "方位，如 BL、BL主受 等" }
         category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
         blurb: { type: string }
         summary: { type: string }
@@ -245,7 +245,7 @@ components:
           bookId: { type: integer, nullable: true }
           title: { type: string }
           author: { type: string }
-          orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+          orientation: { type: string, description: "方位，如 BL、BL主受 等" }
           category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
           rating: { type: integer, nullable: true }
           review: { type: string, nullable: true }
@@ -257,7 +257,7 @@ components:
           bookId: { type: integer, nullable: true }
           title: { type: string }
           author: { type: string }
-          orientation: { type: string, enum: ['BG','BL','GL','无CP','男频','女频'] }
+          orientation: { type: string, description: "方位，如 BL、BL主受 等" }
           category: { type: string, enum: ['爱情','剧情','都市','历史','奇幻','仙侠','同人','海棠','酸涩','职场','无限流','快穿','游戏','科幻','童话','惊悚','悬疑','年代'] }
           rating: { type: integer, nullable: true }
           review: { type: string, nullable: true }

--- a/src/main/java/com/novelgrain/application/book/BookUseCases.java
+++ b/src/main/java/com/novelgrain/application/book/BookUseCases.java
@@ -94,7 +94,7 @@ public class BookUseCases {
     }
 
     private void validateOrientation(String orientation) {
-        if (orientation == null || !BookOrientations.ALL.contains(orientation)) {
+        if (!BookOrientations.isValid(orientation)) {
             throw new org.springframework.web.server.ResponseStatusException(
                     org.springframework.http.HttpStatus.BAD_REQUEST, "INVALID_ORIENTATION");
         }

--- a/src/main/java/com/novelgrain/domain/book/BookOrientations.java
+++ b/src/main/java/com/novelgrain/domain/book/BookOrientations.java
@@ -4,11 +4,18 @@ import java.util.Set;
 
 /**
  * Allowed book orientations used across the application.
+ *
+ * <p>The original implementation only accepted a fixed set of exact
+ * values. However, the frontend may send more specific orientations such
+ * as {@code "BL主受"}.  To keep compatibility while still preventing
+ * completely invalid values, we now validate based on well known
+ * prefixes. Any orientation that starts with one of the prefixes is
+ * considered valid.</p>
  */
 public final class BookOrientations {
     private BookOrientations() {}
 
-    public static final Set<String> ALL = Set.of(
+    private static final Set<String> PREFIXES = Set.of(
             "BG",
             "BL",
             "GL",
@@ -16,4 +23,9 @@ public final class BookOrientations {
             "男频",
             "女频"
     );
+
+    public static boolean isValid(String value) {
+        if (value == null) return false;
+        return PREFIXES.stream().anyMatch(value::startsWith);
+    }
 }


### PR DESCRIPTION
## Summary
- loosen orientation validation to allow prefixed values like `BL主受`
- update OpenAPI spec to document flexible orientation values

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68a689ce72808326bd5413bdee3c28d3